### PR TITLE
Using promises to ensure that we alredy got query result before generiating the response

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,16 +17,24 @@ app.post('/lti', upload.array(), function (req, res, next) {
 });
 
 app.get('/lti', function (req, res) {
-  res.setHeader('Content-Type', 'text/plain; charset=utf-8')
-  Tsugi.mysql();
-  res.end('Expecting an LTI POST to this URL');
-})
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+
+  Tsugi.mysql().then (function (rows){
+     res.end('Expecting an LTI POST to this URL');
+  }).catch(function (err){
+     res.end('Tsugi Test Failed!');
+  });
+});
 
 app.get('/', function (req, res) {
-  res.setHeader('Content-Type', 'text/plain; charset=utf-8')
-  Tsugi.mysql();
-  res.end('Tsugi Test complete!')
-})
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+
+  Tsugi.mysql().then (function (rows){
+     res.end('Tsugi Test complete!')
+  }).catch(function (err){
+     res.end('Tsugi Test Failed!');
+  });
+});
 
 console.log("Test mysql connection at http://localhost:3000");
 console.log("Test oauth1 url=http://localhost:3000/lti key=12345 secret=secret");

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "multer": "^1.1.0",
     "mysql": ">=1.0.0",
     "oauth-sign": "git://github.com/csev/oauth-sign.git#master",
-    "url": ">=0.0.0"
+    "url": ">=0.0.0",
+    "q": "1.4.1"
   },
   "description": "A Sample Tsugi Application in Node",
   "main": "http.js",

--- a/tsugi.js
+++ b/tsugi.js
@@ -1,9 +1,13 @@
 
+var $q = require ('q');
+
 exports.version = "0.0.1";
 
 exports.mysql = function() {
 
+    var deferred = $q.defer();
     var mysql = require('mysql');
+ 
     var connection = mysql.createConnection({
         host     : 'localhost',
         port     : 8889,
@@ -14,12 +18,16 @@ exports.mysql = function() {
 
     connection.connect();
     connection.query('SELECT * from mjjs', function(err, rows, fields) {
-        if (!err)
+        if (!err){
+            deferred.resolve (rows);
             console.log('The solution is: ', rows);
-        else
-            console.log('Error while performing Query.');
+        } else {
+            deferred.reject(err);
+            console.log('Error while performing Query.', err );
+        }
     });
     connection.end();
+    return deferred.promise;
 }
 
 exports.validate = function(req, res) {


### PR DESCRIPTION
Introducing the use of promises in the example. A good way to proceed in order to wait for query results before to send http response. The alternative is callback chains :-(
